### PR TITLE
Make NvAPI shut the fuck up

### DIFF
--- a/dlls/nvapi/nvapi.c
+++ b/dlls/nvapi/nvapi.c
@@ -505,6 +505,18 @@ static NvAPI_Status CDECL NvAPI_DISP_GetGDIPrimaryDisplayId(NvU32* displayId)
     return NVAPI_OK;
 }
 
+static NvAPI_Status CDECL NvAPI_DISP_GetDisplayIdByDisplayName(const char * displayName, NvU32* displayId)
+{
+    TRACE("(%s, %p)\n", displayName, displayId);
+
+    if (!displayName || !displayId)
+        return NVAPI_INVALID_ARGUMENT;
+
+    *displayId = FAKE_DISPLAY_ID;
+    return NVAPI_OK;
+}
+
+
 static NvAPI_Status CDECL NvAPI_EnumNvidiaDisplayHandle(NvU32 thisEnum, NvDisplayHandle *pNvDispHandle)
 {
     TRACE("(%u, %p)\n", thisEnum, pNvDispHandle);
@@ -531,6 +543,17 @@ static NvAPI_Status CDECL NvAPI_SYS_GetDriverAndBranchVersion(NvU32* pDriverVers
     memcpy(szBuildBranchString, build_str, sizeof(build_str));
     *pDriverVersion = 33788;
 
+    return NVAPI_OK;
+}
+
+static NvAPI_Status CDECL NvAPI_SYS_GetPhysicalGpuFromDisplayId(NvU32 displayId, NvPhysicalGpuHandle *hPhysicalGpu)
+{
+    TRACE("(%u, %p)\n", displayId, hPhysicalGpu);
+
+    if (!displayId || !hPhysicalGpu)
+        return NVAPI_INVALID_ARGUMENT;
+
+    *hPhysicalGpu = FAKE_PHYSICAL_GPU;
     return NVAPI_OK;
 }
 
@@ -681,6 +704,48 @@ static NvAPI_Status CDECL NvAPI_GPU_GetGpuCoreCount(NvPhysicalGpuHandle hPhysica
     return NVAPI_OK;
 }
 
+static NvAPI_Status CDECL NvAPI_GPU_GetSystemType(NvPhysicalGpuHandle hPhysicalGpu, NV_SYSTEM_TYPE *pSystemType)
+{
+    TRACE("(%p, %p)\n", hPhysicalGpu, pSystemType);
+
+    if (!hPhysicalGpu)
+        return NVAPI_EXPECTED_PHYSICAL_GPU_HANDLE;
+
+    if (hPhysicalGpu != FAKE_PHYSICAL_GPU)
+    {
+        FIXME("invalid handle: %p\n", hPhysicalGpu);
+        return NVAPI_INVALID_HANDLE;
+    }
+
+    if (!pSystemType)
+        return NVAPI_INVALID_ARGUMENT;
+
+    /* The choice of being a desktop is arguable
+       but it seems like the "safest" choice. */
+    *pSystemType = NV_SYSTEM_TYPE_DESKTOP;
+    return NVAPI_OK;
+}
+
+static NvAPI_Status CDECL NvAPI_GPU_GetThermalSettings(NvPhysicalGpuHandle hPhysicalGpu, NvU32 sensorIndex, NV_GPU_THERMAL_SETTINGS *pThermalSettings)
+{
+    TRACE("(%p, %u, %p)\n", hPhysicalGpu, sensorIndex, pThermalSettings);
+
+    if (!hPhysicalGpu)
+        return NVAPI_EXPECTED_PHYSICAL_GPU_HANDLE;
+
+    if (hPhysicalGpu != FAKE_PHYSICAL_GPU)
+    {
+        FIXME("invalid handle: %p\n", hPhysicalGpu);
+        return NVAPI_INVALID_HANDLE;
+    }
+
+    if (!sensorIndex || !pThermalSettings)
+        return NVAPI_INVALID_ARGUMENT;
+
+    *pThermalSettings = NVAPI_THERMAL_CONTROLLER_NONE;
+    return NVAPI_OK;
+}
+
 void* CDECL nvapi_QueryInterface(unsigned int offset)
 {
     static const struct
@@ -716,8 +781,10 @@ void* CDECL nvapi_QueryInterface(unsigned int offset)
         {0x33c7358c, NULL}, /* This functions seems to be optional */
         {0x593e8644, NULL}, /* This functions seems to be optional */
         {0x1e9d8a31, NvAPI_DISP_GetGDIPrimaryDisplayId},
+        {0xae457190, NvAPI_DISP_GetDisplayIdByDisplayName},
         {0x9abdd40d, NvAPI_EnumNvidiaDisplayHandle},
         {0x2926aaad, NvAPI_SYS_GetDriverAndBranchVersion},
+        {0x9ea74659, NvAPI_SYS_GetPhysicalGpuFromDisplayId},
         {0xd22bdd7e, NvAPI_Unload},
         {0x4b708b54, NvAPI_D3D_GetCurrentSLIState},
         {0xee1370cf, NvAPI_GetLogicalGPUFromDisplay},
@@ -726,6 +793,8 @@ void* CDECL nvapi_QueryInterface(unsigned int offset)
         {0x46fbeb03, NvAPI_GPU_GetPhysicalFrameBufferSize},
         {0x5a04b644, NvAPI_GPU_GetVirtualFrameBufferSize},
         {0xc7026a87, NvAPI_GPU_GetGpuCoreCount},
+        {0xbaaabfcc, NvAPI_GPU_GetSystemType},
+        {0xe3640a56, NvAPI_GPU_GetThermalSettings}
     };
     unsigned int i;
     TRACE("(%x)\n", offset);

--- a/include/nvapi.h
+++ b/include/nvapi.h
@@ -47,6 +47,12 @@ typedef unsigned int NvU32;
 #define NVAPI_ADVANCED_DISPLAY_HEADS 4
 #define NVAPI_MAX_DISPLAYS (NVAPI_PHYSICAL_GPUS * NVAPI_ADVANCED_DISPLAY_HEADS)
 
+#define NVAPI_THERMAL_CONTROLLER_NONE 0
+
+#define NV_SYSTEM_TYPE_UNKNOWN 0
+#define NV_SYSTEM_TYPE_LAPTOP 1
+#define NV_SYSTEM_TYPE_DESKTOP 2
+
 typedef char NvAPI_ShortString[NVAPI_SHORT_STRING_MAX];
 
 #define MAKE_NVAPI_VERSION(type,version) (NvU32)(sizeof(type) | ((version)<<16))
@@ -56,6 +62,8 @@ typedef void *NvLogicalGpuHandle;
 typedef void *NvDisplayHandle;
 typedef void *StereoHandle;
 typedef void *NVDX_ObjectHandle;
+typedef void *NV_GPU_THERMAL_SETTINGS;
+typedef void *NV_SYSTEM_TYPE;
 
 typedef struct
 {


### PR DESCRIPTION

This provides fake implementations for the following NvAPI functions:
NvAPI_DISP_GetDisplayIdByDisplayName
NvAPI_SYS_GetPhysicalGpuFromDisplayId
NvAPI_GPU_GetSystemType
NvAPI_GPU_GetThermalSettings

They're built in the same fakeish manner as the rest of the PhysX nvapi
stubs. These four stubs makes fixme:nvapi:unimplemented_stub shut up
when playing Overwatch.

---
With this patch, the remaining noise is:
```
fixme:nvapi:unimplemented_stub function 0x694d52e is unimplemented!
fixme:nvapi:unimplemented_stub function 0x6ff81213 is unimplemented!
```

`0x6ff81213` is NvAPI_GPU_GetPstates20, which I didn't bother to implement because it's complicated (there's like a struct and a bunch of values and there's structs inside it and...) and Overwatch only calls it once anyways.

`0x694d52e` is NvAPI_DRS_CreateSession, which is used for the GeForce Experience "automagically optimized settings" stuff. This felt like kind of a lot of work to implement for no real gain, since I'm sure as soon as it stops returning NVAPI_ERROR Overwatch is going to start calling other NvAPI_DRS_ functions.

Going to write some tests for these to go along with the other nvapi fakes, just as soon as I wrap my head around how Wine integration tests work.