### PR TITLE
wined3d: Remove brackets from shader_in_out varying

### DIFF
--- a/dlls/wined3d/glsl_shader.c
+++ b/dlls/wined3d/glsl_shader.c
@@ -842,7 +842,8 @@ static void shader_glsl_generate_transform_feedback_varyings(const struct wined3
                 continue;
             }
 
-            string_buffer_sprintf(buffer, "shader_in_out.reg[%u]", e->register_idx);
+            string_buffer_sprintf(buffer, "shader_in_out.reg%u", e->register_idx);
+            FIXME("appending variable shader_in_out.reg%u\n", e->register_idx);
             append_transform_feedback_varying(varyings, &count, &strings, &length, buffer);
         }
 


### PR DESCRIPTION
Influenced by the following glsl error line:

```
Link info
---------
error: Varying (named shader_in_out.reg[0]) specified but not present in the program object.
```

Includes a fixme in case it breaks something in the future. I don't really know if this is right or not, but I do know this fixes the GLSL link errors in OW without any visible negative side effects.